### PR TITLE
Fix vehicle modal submission

### DIFF
--- a/web-auto-branch/src/pages/Vehicles/components/VehicleModal.jsx
+++ b/web-auto-branch/src/pages/Vehicles/components/VehicleModal.jsx
@@ -59,21 +59,48 @@ function VehicleModal({ open, onOpenChange, vehicle, refreshVehicle }) {
     async function handleSubmit(e) {
         e.preventDefault();
         try {
+            const sanitizedPlate = plate.trim().toUpperCase();
             let req;
             if (!vehicle) {
-                req = await createVehicle(brand, model, version, year, gearbox, color, motorization, plate, km, value, user.branchId ? user.branchId : branchId);
-            }
-            else if (vehicle) {
-                req = await editVehicle(parseInt(vehicle.id), brand, model, version, year, gearbox, color, motorization, plate, parseFloat(km), parseFloat(value), branchId);
+                req = await createVehicle(
+                    brand,
+                    model,
+                    version,
+                    year,
+                    gearbox,
+                    color,
+                    motorization,
+                    sanitizedPlate,
+                    km,
+                    value,
+                    user.branchId ? user.branchId : branchId,
+                );
+            } else {
+                req = await editVehicle(
+                    parseInt(vehicle.id),
+                    brand,
+                    model,
+                    version,
+                    year,
+                    gearbox,
+                    color,
+                    motorization,
+                    sanitizedPlate,
+                    parseFloat(km),
+                    parseFloat(value),
+                    branchId,
+                );
                 refreshVehicle();
             }
+
             if (req) {
+                onOpenChange(false);
                 clearForm();
             }
         } catch (err) {
             console.error(err);
         }
-    };
+    }
 
     return (
         <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
@@ -252,9 +279,7 @@ function VehicleModal({ open, onOpenChange, vehicle, refreshVehicle }) {
                         </>
                     )}
                     <Flex justify="end">
-                        <AlertDialog.Action>
-                            <Button id="vehicle-submit" type="submit" className={styles.saveButton}>Salvar</Button>
-                        </AlertDialog.Action>
+                        <Button id="vehicle-submit" type="submit" className={styles.saveButton}>Salvar</Button>
                     </Flex>
                 </form>
             </AlertDialog.Content>


### PR DESCRIPTION
## Summary
- sanitize plate value before submitting a vehicle
- close modal only after successful vehicle submission
- keep focus inside form on failed attempt
- remove AlertDialog.Action wrapper so modal does not auto-close

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8236a98832683c6a47885b368fa